### PR TITLE
Replace syn::export::TokenStream with proc_macro2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ path = "tests/progress.rs"
 
 [dependencies]
 fire-rs-core = {path="./fire-rs-core", version="0.2"}
-clap = "2.33"
+clap = "2.34"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fire-rs"
 version = "0.2.4-alpha.0"
 authors = ["fun4wut <nihouze@163.com>"]
 description = "A Rust implementation of Python-fire"
-repository = "https://github.com/fun4wut/fire-rs"
+repository = "https://github.com/chq-matteo/fire-rs"
 categories = ["command-line-interface", "development-tools"]
 keywords = ["fire", "cli"]
 edition = "2018"
@@ -17,5 +17,5 @@ name = "tests"
 path = "tests/progress.rs"
 
 [dependencies]
-fire-rs-core = {path="./fire-rs-core", version="0.2"}
+fire-rs-core = {path="./fire-rs-core", version="0.3" }
 clap = "2.34"

--- a/fire-rs-core/Cargo.toml
+++ b/fire-rs-core/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [dependencies]
 syn = {version = "1.0", features = ["full"]}
 quote = "1.0"
+proc-macro2 = "1.0"
 
 # cargo-release config
 [package.metadata.release]

--- a/fire-rs-core/Cargo.toml
+++ b/fire-rs-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fire-rs-core"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["fun4wut <nihouze@163.com>"]
 description = "The core proc-macro crate for fire-rs"
 repository = "https://github.com/fun4wut/fire-rs"

--- a/fire-rs-core/src/lib.rs
+++ b/fire-rs-core/src/lib.rs
@@ -1,9 +1,9 @@
 //! Core crate for proc-macro
 extern crate proc_macro;
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use std::ops::Deref;
-use syn::export::TokenStream2;
 use syn::{FnArg, Ident, Item, Pat};
 
 /// This macro will generate 4 functions to create cli.


### PR DESCRIPTION
# Summary

Currently the package is broken due to this error

```
error[E0432]: unresolved import `syn::export`
 --> /home/.../.cargo/git/checkouts/fire-rs-ef13225ad72ec6b6/442ec5e/fire-rs-core/src/lib.rs:6:10
  |
6 | use syn::export::TokenStream2;
  |          ^^^^^^ could not find `export` in `syn`
```

because syn::export was removed from syn without bumping the semver version from 1.0

This pr replaces `syn::export::TokenStream2` with `proc_macro2::TokenStream`

# Tests
```
cargo test

    Finished test [unoptimized + debuginfo] target(s) in 0.01s
     Running unittests src/lib.rs (target/debug/deps/fire_rs-78a8398ce519fad7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/progress.rs (target/debug/deps/tests-f8aba55c135574d8)

running 4 tests
test no_args ... ok
test two_args ... ok
test omit_rest_args ... ok
test with_name ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests fire-rs

running 1 test
test src/lib.rs - (line 11) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.27s
```